### PR TITLE
SUPESC-193 Backport for fixed breadcrumbs for a product.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,11 +11,13 @@
     "spryker/kernel": "^3.30.0",
     "spryker/product": "^5.5.0 || ^6.0.0",
     "spryker/product-category": "^4.5.0",
+    "spryker/product-category-storage-extension": "^1.0.0",
     "spryker/propel-orm": "^1.5.0",
     "spryker/storage": "^3.4.0",
     "spryker/synchronization": "^0.2.0 || ^1.0.0",
     "spryker/synchronization-behavior": "^1.0.0",
     "spryker/synchronization-extension": "^1.0.0",
+    "spryker/transfer": "^3.27.0",
     "spryker/url": "^3.0.0"
   },
   "require-dev": {

--- a/dependency.json
+++ b/dependency.json
@@ -1,0 +1,5 @@
+{
+    "include": {
+        "spryker/transfer": "Provides transfer objects definition with strict types."
+    }
+}

--- a/src/Spryker/Client/ProductCategoryStorage/Filter/ProductCategoryStorageFilter.php
+++ b/src/Spryker/Client/ProductCategoryStorage/Filter/ProductCategoryStorageFilter.php
@@ -12,10 +12,10 @@ use Generated\Shared\Transfer\ProductCategoryStorageTransfer;
 class ProductCategoryStorageFilter implements ProductCategoryStorageFilterInterface
 {
     /**
-     * @param array<\Generated\Shared\Transfer\ProductCategoryStorageTransfer> $productCategoryStorageTransfers
+     * @param array<int, \Generated\Shared\Transfer\ProductCategoryStorageTransfer> $productCategoryStorageTransfers
      * @param string $httpReferer
      *
-     * @return array<\Generated\Shared\Transfer\ProductCategoryStorageTransfer>
+     * @return list<\Generated\Shared\Transfer\ProductCategoryStorageTransfer>
      */
     public function filterProductCategoriesByHttpReferer(array $productCategoryStorageTransfers, string $httpReferer): array
     {
@@ -23,12 +23,12 @@ class ProductCategoryStorageFilter implements ProductCategoryStorageFilterInterf
     }
 
     /**
-     * @param array<\Generated\Shared\Transfer\ProductCategoryStorageTransfer> $productCategoryStorageTransfers
+     * @param array<int, \Generated\Shared\Transfer\ProductCategoryStorageTransfer> $productCategoryStorageTransfers
      * @param string $httpReferer
-     * @param array<\Generated\Shared\Transfer\ProductCategoryStorageTransfer> $filteredProductCategoryStorageTransfers
+     * @param list<\Generated\Shared\Transfer\ProductCategoryStorageTransfer> $filteredProductCategoryStorageTransfers
      * @param \Generated\Shared\Transfer\ProductCategoryStorageTransfer|null $relativeProductCategoryStorageTransfer
      *
-     * @return array<\Generated\Shared\Transfer\ProductCategoryStorageTransfer>
+     * @return list<\Generated\Shared\Transfer\ProductCategoryStorageTransfer>
      */
     protected function filterProductCategoriesRecursive(
         array $productCategoryStorageTransfers,

--- a/src/Spryker/Client/ProductCategoryStorage/Filter/ProductCategoryStorageFilter.php
+++ b/src/Spryker/Client/ProductCategoryStorage/Filter/ProductCategoryStorageFilter.php
@@ -1,0 +1,103 @@
+<?php
+
+/**
+ * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
+ * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
+ */
+
+namespace Spryker\Client\ProductCategoryStorage\Filter;
+
+use Generated\Shared\Transfer\ProductCategoryStorageTransfer;
+
+class ProductCategoryStorageFilter implements ProductCategoryStorageFilterInterface
+{
+    /**
+     * @param array<\Generated\Shared\Transfer\ProductCategoryStorageTransfer> $productCategoryStorageTransfers
+     * @param string $httpReferer
+     *
+     * @return array<\Generated\Shared\Transfer\ProductCategoryStorageTransfer>
+     */
+    public function filterProductCategoriesByHttpReferer(array $productCategoryStorageTransfers, string $httpReferer): array
+    {
+        return $this->filterProductCategoriesRecursive($productCategoryStorageTransfers, $httpReferer);
+    }
+
+    /**
+     * @param array<\Generated\Shared\Transfer\ProductCategoryStorageTransfer> $productCategoryStorageTransfers
+     * @param string $httpReferer
+     * @param array<\Generated\Shared\Transfer\ProductCategoryStorageTransfer> $filteredProductCategoryStorageTransfers
+     * @param \Generated\Shared\Transfer\ProductCategoryStorageTransfer|null $relativeProductCategoryStorageTransfer
+     *
+     * @return array<\Generated\Shared\Transfer\ProductCategoryStorageTransfer>
+     */
+    protected function filterProductCategoriesRecursive(
+        array $productCategoryStorageTransfers,
+        string $httpReferer,
+        array $filteredProductCategoryStorageTransfers = [],
+        ?ProductCategoryStorageTransfer $relativeProductCategoryStorageTransfer = null
+    ): array {
+        foreach ($productCategoryStorageTransfers as $key => $productCategoryStorageTransfer) {
+            unset($productCategoryStorageTransfers[$key]);
+            if (!$this->isCategoryApplicableForFiltering($productCategoryStorageTransfer, $httpReferer, $relativeProductCategoryStorageTransfer)) {
+                continue;
+            }
+
+            $filteredProductCategoryStorageTransfers[] = $productCategoryStorageTransfer;
+
+            $filteredProductCategoryStorageTransfers = $this->filterProductCategoriesRecursive(
+                $productCategoryStorageTransfers,
+                $httpReferer,
+                $filteredProductCategoryStorageTransfers,
+                $productCategoryStorageTransfer,
+            );
+
+            break;
+        }
+
+        return $filteredProductCategoryStorageTransfers;
+    }
+
+    /**
+     * @param \Generated\Shared\Transfer\ProductCategoryStorageTransfer $productCategoryStorageTransfer
+     * @param string $httpReferer
+     * @param \Generated\Shared\Transfer\ProductCategoryStorageTransfer|null $relativeProductCategoryStorageTransfer
+     *
+     * @return bool
+     */
+    protected function isCategoryApplicableForFiltering(
+        ProductCategoryStorageTransfer $productCategoryStorageTransfer,
+        string $httpReferer,
+        ?ProductCategoryStorageTransfer $relativeProductCategoryStorageTransfer = null
+    ): bool {
+        if ($relativeProductCategoryStorageTransfer && !$this->isRelativeCategory($productCategoryStorageTransfer, $relativeProductCategoryStorageTransfer)) {
+            return false;
+        }
+
+        if ($httpReferer && strpos($httpReferer, $productCategoryStorageTransfer->getUrlOrFail()) === false) {
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * @param \Generated\Shared\Transfer\ProductCategoryStorageTransfer $productCategoryStorageTransfer
+     * @param \Generated\Shared\Transfer\ProductCategoryStorageTransfer $relativeProductCategoryStorageTransfer
+     *
+     * @return bool
+     */
+    protected function isRelativeCategory(
+        ProductCategoryStorageTransfer $productCategoryStorageTransfer,
+        ProductCategoryStorageTransfer $relativeProductCategoryStorageTransfer
+    ): bool {
+        if (in_array($relativeProductCategoryStorageTransfer->getCategoryId(), $productCategoryStorageTransfer->getParentCategoryIds(), true)) {
+            return true;
+        }
+
+        if (in_array($productCategoryStorageTransfer->getCategoryId(), $relativeProductCategoryStorageTransfer->getParentCategoryIds(), true)) {
+            return true;
+        }
+
+        return false;
+    }
+}

--- a/src/Spryker/Client/ProductCategoryStorage/Filter/ProductCategoryStorageFilterInterface.php
+++ b/src/Spryker/Client/ProductCategoryStorage/Filter/ProductCategoryStorageFilterInterface.php
@@ -1,0 +1,19 @@
+<?php
+
+/**
+ * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
+ * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
+ */
+
+namespace Spryker\Client\ProductCategoryStorage\Filter;
+
+interface ProductCategoryStorageFilterInterface
+{
+    /**
+     * @param array<\Generated\Shared\Transfer\ProductCategoryStorageTransfer> $productCategoryStorageTransfers
+     * @param string $httpReferer
+     *
+     * @return array<\Generated\Shared\Transfer\ProductCategoryStorageTransfer>
+     */
+    public function filterProductCategoriesByHttpReferer(array $productCategoryStorageTransfers, string $httpReferer): array;
+}

--- a/src/Spryker/Client/ProductCategoryStorage/Filter/ProductCategoryStorageFilterInterface.php
+++ b/src/Spryker/Client/ProductCategoryStorage/Filter/ProductCategoryStorageFilterInterface.php
@@ -10,10 +10,10 @@ namespace Spryker\Client\ProductCategoryStorage\Filter;
 interface ProductCategoryStorageFilterInterface
 {
     /**
-     * @param array<\Generated\Shared\Transfer\ProductCategoryStorageTransfer> $productCategoryStorageTransfers
+     * @param array<int, \Generated\Shared\Transfer\ProductCategoryStorageTransfer> $productCategoryStorageTransfers
      * @param string $httpReferer
      *
-     * @return array<\Generated\Shared\Transfer\ProductCategoryStorageTransfer>
+     * @return list<\Generated\Shared\Transfer\ProductCategoryStorageTransfer>
      */
     public function filterProductCategoriesByHttpReferer(array $productCategoryStorageTransfers, string $httpReferer): array;
 }

--- a/src/Spryker/Client/ProductCategoryStorage/ProductCategoryStorageClient.php
+++ b/src/Spryker/Client/ProductCategoryStorage/ProductCategoryStorageClient.php
@@ -33,7 +33,7 @@ class ProductCategoryStorageClient extends AbstractClient implements ProductCate
 
         return $this->getFactory()
             ->createProductCategoryStorageReader()
-            ->findProductAbstractCategory($idProductAbstract, $locale);
+            ->findProductAbstractCategory($idProductAbstract, $locale, $storeName);
     }
 
     /**
@@ -56,5 +56,39 @@ class ProductCategoryStorageClient extends AbstractClient implements ProductCate
         return $this->getFactory()
             ->createProductCategoryStorageReader()
             ->findBulkProductAbstractCategory($productAbstractIds, $localeName);
+    }
+
+
+    /**
+     * {@inheritDoc}
+     *
+     * @api
+     *
+     * @param array<\Generated\Shared\Transfer\ProductCategoryStorageTransfer> $productCategoryStorageTransfers
+     * @param string $httpReferer
+     *
+     * @return array<\Generated\Shared\Transfer\ProductCategoryStorageTransfer>
+     */
+    public function filterProductCategoriesByHttpReferer(array $productCategoryStorageTransfers, string $httpReferer): array
+    {
+        return $this->getFactory()
+            ->createProductCategoryStorageFilter()
+            ->filterProductCategoriesByHttpReferer($productCategoryStorageTransfers, $httpReferer);
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @api
+     *
+     * @param array<\Generated\Shared\Transfer\ProductCategoryStorageTransfer> $productCategoryStorageTransfers
+     *
+     * @return array<\Generated\Shared\Transfer\ProductCategoryStorageTransfer>
+     */
+    public function sortProductCategories(array $productCategoryStorageTransfers): array
+    {
+        return $this->getFactory()
+            ->createProductCategoryStorageSorter()
+            ->sortProductCategories($productCategoryStorageTransfers);
     }
 }

--- a/src/Spryker/Client/ProductCategoryStorage/ProductCategoryStorageClient.php
+++ b/src/Spryker/Client/ProductCategoryStorage/ProductCategoryStorageClient.php
@@ -64,10 +64,10 @@ class ProductCategoryStorageClient extends AbstractClient implements ProductCate
      *
      * @api
      *
-     * @param array<\Generated\Shared\Transfer\ProductCategoryStorageTransfer> $productCategoryStorageTransfers
+     * @param array<int, \Generated\Shared\Transfer\ProductCategoryStorageTransfer> $productCategoryStorageTransfers
      * @param string $httpReferer
      *
-     * @return array<\Generated\Shared\Transfer\ProductCategoryStorageTransfer>
+     * @return list<\Generated\Shared\Transfer\ProductCategoryStorageTransfer>
      */
     public function filterProductCategoriesByHttpReferer(array $productCategoryStorageTransfers, string $httpReferer): array
     {
@@ -81,9 +81,9 @@ class ProductCategoryStorageClient extends AbstractClient implements ProductCate
      *
      * @api
      *
-     * @param array<\Generated\Shared\Transfer\ProductCategoryStorageTransfer> $productCategoryStorageTransfers
+     * @param array<int, \Generated\Shared\Transfer\ProductCategoryStorageTransfer> $productCategoryStorageTransfers
      *
-     * @return array<\Generated\Shared\Transfer\ProductCategoryStorageTransfer>
+     * @return list<\Generated\Shared\Transfer\ProductCategoryStorageTransfer>
      */
     public function sortProductCategories(array $productCategoryStorageTransfers): array
     {

--- a/src/Spryker/Client/ProductCategoryStorage/ProductCategoryStorageClient.php
+++ b/src/Spryker/Client/ProductCategoryStorage/ProductCategoryStorageClient.php
@@ -19,6 +19,8 @@ class ProductCategoryStorageClient extends AbstractClient implements ProductCate
      *
      * @api
      *
+     * @deprecated Use {@link \Spryker\Client\ProductCategoryStorage\ProductCategoryStorageClient::findBulkProductAbstractCategory()} instead.
+     *
      * @param int $idProductAbstract
      * @param string $locale
      * @param string|null $storeName
@@ -33,7 +35,7 @@ class ProductCategoryStorageClient extends AbstractClient implements ProductCate
 
         return $this->getFactory()
             ->createProductCategoryStorageReader()
-            ->findProductAbstractCategory($idProductAbstract, $locale, $storeName);
+            ->findProductAbstractCategory($idProductAbstract, $locale);
     }
 
     /**
@@ -55,7 +57,7 @@ class ProductCategoryStorageClient extends AbstractClient implements ProductCate
 
         return $this->getFactory()
             ->createProductCategoryStorageReader()
-            ->findBulkProductAbstractCategory($productAbstractIds, $localeName);
+            ->findBulkProductAbstractCategory($productAbstractIds, $localeName, $storeName);
     }
 
 

--- a/src/Spryker/Client/ProductCategoryStorage/ProductCategoryStorageClientInterface.php
+++ b/src/Spryker/Client/ProductCategoryStorage/ProductCategoryStorageClientInterface.php
@@ -47,10 +47,10 @@ interface ProductCategoryStorageClientInterface
      *
      * @api
      *
-     * @param array<\Generated\Shared\Transfer\ProductCategoryStorageTransfer> $productCategoryStorageTransfers
+     * @param array<int, \Generated\Shared\Transfer\ProductCategoryStorageTransfer> $productCategoryStorageTransfers
      * @param string $httpReferer
      *
-     * @return array<\Generated\Shared\Transfer\ProductCategoryStorageTransfer>
+     * @return list<\Generated\Shared\Transfer\ProductCategoryStorageTransfer>
      */
     public function filterProductCategoriesByHttpReferer(array $productCategoryStorageTransfers, string $httpReferer): array;
 
@@ -61,9 +61,9 @@ interface ProductCategoryStorageClientInterface
      *
      * @api
      *
-     * @param array<\Generated\Shared\Transfer\ProductCategoryStorageTransfer> $productCategoryStorageTransfers
+     * @param array<int, \Generated\Shared\Transfer\ProductCategoryStorageTransfer> $productCategoryStorageTransfers
      *
-     * @return array<\Generated\Shared\Transfer\ProductCategoryStorageTransfer>
+     * @return list<\Generated\Shared\Transfer\ProductCategoryStorageTransfer>
      */
     public function sortProductCategories(array $productCategoryStorageTransfers): array;
 }

--- a/src/Spryker/Client/ProductCategoryStorage/ProductCategoryStorageClientInterface.php
+++ b/src/Spryker/Client/ProductCategoryStorage/ProductCategoryStorageClientInterface.php
@@ -13,9 +13,10 @@ interface ProductCategoryStorageClientInterface
      * Specification:
      * - Returns Product Abstract Category by id.
      * - Forward compatibility (from next major): only product abstract categories assigned with passed $storeName will be returned.
-     * - Expands Product Abstract Category by {@link \Spryker\Client\ProductCategoryStorageExtension\Dependency\Plugin\ProductAbstractCategoryStorageCollectionExpanderPluginInterface} plugin stack execution.
      *
      * @api
+     *
+     * @deprecated Use {@link \Spryker\Client\ProductCategoryStorage\ProductCategoryStorageClientInterface::findBulkProductAbstractCategory()} instead.
      *
      * @param int $idProductAbstract
      * @param string $locale
@@ -28,6 +29,7 @@ interface ProductCategoryStorageClientInterface
     /**
      * Specification:
      * - Returns Categories grouped by Product Abstract id.
+     * - Executes {@link \Spryker\Client\ProductCategoryStorageExtension\Dependency\Plugin\ProductAbstractCategoryStorageCollectionExpanderPluginInterface} plugins stack.
      * - Forward compatibility (from next major): only product abstract categories assigned with passed $storeName will be returned.
      *
      * @api

--- a/src/Spryker/Client/ProductCategoryStorage/ProductCategoryStorageClientInterface.php
+++ b/src/Spryker/Client/ProductCategoryStorage/ProductCategoryStorageClientInterface.php
@@ -13,6 +13,7 @@ interface ProductCategoryStorageClientInterface
      * Specification:
      * - Returns Product Abstract Category by id.
      * - Forward compatibility (from next major): only product abstract categories assigned with passed $storeName will be returned.
+     * - Expands Product Abstract Category by {@link \Spryker\Client\ProductCategoryStorageExtension\Dependency\Plugin\ProductAbstractCategoryStorageCollectionExpanderPluginInterface} plugin stack execution.
      *
      * @api
      *
@@ -38,4 +39,31 @@ interface ProductCategoryStorageClientInterface
      * @return \Generated\Shared\Transfer\ProductAbstractCategoryStorageTransfer[]
      */
     public function findBulkProductAbstractCategory(array $productAbstractIds, string $localeName, ?string $storeName = null): array;
+
+    /**
+     * Specification:
+     * - Requires `ProductCategoryStorageTransfer.url` to be set.
+     * - Returns Product Categories filtered by http referer.
+     *
+     * @api
+     *
+     * @param array<\Generated\Shared\Transfer\ProductCategoryStorageTransfer> $productCategoryStorageTransfers
+     * @param string $httpReferer
+     *
+     * @return array<\Generated\Shared\Transfer\ProductCategoryStorageTransfer>
+     */
+    public function filterProductCategoriesByHttpReferer(array $productCategoryStorageTransfers, string $httpReferer): array;
+
+    /**
+     * Specification:
+     * - Requires `ProductCategoryStorageTransfer.categoryId` to be set.
+     * - Returns Product Categories sorted in order from parent to child.
+     *
+     * @api
+     *
+     * @param array<\Generated\Shared\Transfer\ProductCategoryStorageTransfer> $productCategoryStorageTransfers
+     *
+     * @return array<\Generated\Shared\Transfer\ProductCategoryStorageTransfer>
+     */
+    public function sortProductCategories(array $productCategoryStorageTransfers): array;
 }

--- a/src/Spryker/Client/ProductCategoryStorage/ProductCategoryStorageDependencyProvider.php
+++ b/src/Spryker/Client/ProductCategoryStorage/ProductCategoryStorageDependencyProvider.php
@@ -21,6 +21,11 @@ class ProductCategoryStorageDependencyProvider extends AbstractDependencyProvide
     public const SERVICE_SYNCHRONIZATION = 'SERVICE_SYNCHRONIZATION';
 
     /**
+     * @var string
+     */
+    public const PLUGINS_PRODUCT_ABSTRACT_CATEGORY_STORAGE_COLLECTION_EXPANDER = 'PLUGINS_PRODUCT_ABSTRACT_CATEGORY_STORAGE_COLLECTION_EXPANDER';
+
+    /**
      * @param \Spryker\Client\Kernel\Container $container
      *
      * @return \Spryker\Client\Kernel\Container
@@ -29,6 +34,7 @@ class ProductCategoryStorageDependencyProvider extends AbstractDependencyProvide
     {
         $container = $this->addStorageClient($container);
         $container = $this->addSynchronizationService($container);
+        $container = $this->addProductAbstractCategoryStorageCollectionExpanderPlugins($container);
 
         return $container;
     }
@@ -59,5 +65,27 @@ class ProductCategoryStorageDependencyProvider extends AbstractDependencyProvide
         });
 
         return $container;
+    }
+
+    /**
+     * @param \Spryker\Client\Kernel\Container $container
+     *
+     * @return \Spryker\Client\Kernel\Container
+     */
+    protected function addProductAbstractCategoryStorageCollectionExpanderPlugins(Container $container): Container
+    {
+        $container->set(static::PLUGINS_PRODUCT_ABSTRACT_CATEGORY_STORAGE_COLLECTION_EXPANDER, function () {
+            return $this->getProductAbstractCategoryStorageCollectionExpanderPlugins();
+        });
+
+        return $container;
+    }
+
+    /**
+     * @return array<\Spryker\Client\ProductCategoryStorageExtension\Dependency\Plugin\ProductAbstractCategoryStorageCollectionExpanderPluginInterface>
+     */
+    protected function getProductAbstractCategoryStorageCollectionExpanderPlugins(): array
+    {
+        return [];
     }
 }

--- a/src/Spryker/Client/ProductCategoryStorage/ProductCategoryStorageDependencyProvider.php
+++ b/src/Spryker/Client/ProductCategoryStorage/ProductCategoryStorageDependencyProvider.php
@@ -82,7 +82,7 @@ class ProductCategoryStorageDependencyProvider extends AbstractDependencyProvide
     }
 
     /**
-     * @return array<\Spryker\Client\ProductCategoryStorageExtension\Dependency\Plugin\ProductAbstractCategoryStorageCollectionExpanderPluginInterface>
+     * @return list<\Spryker\Client\ProductCategoryStorageExtension\Dependency\Plugin\ProductAbstractCategoryStorageCollectionExpanderPluginInterface>
      */
     protected function getProductAbstractCategoryStorageCollectionExpanderPlugins(): array
     {

--- a/src/Spryker/Client/ProductCategoryStorage/ProductCategoryStorageFactory.php
+++ b/src/Spryker/Client/ProductCategoryStorage/ProductCategoryStorageFactory.php
@@ -8,6 +8,10 @@
 namespace Spryker\Client\ProductCategoryStorage;
 
 use Spryker\Client\Kernel\AbstractFactory;
+use Spryker\Client\ProductCategoryStorage\Filter\ProductCategoryStorageFilter;
+use Spryker\Client\ProductCategoryStorage\Filter\ProductCategoryStorageFilterInterface;
+use Spryker\Client\ProductCategoryStorage\Sorter\ProductCategoryStorageSorter;
+use Spryker\Client\ProductCategoryStorage\Sorter\ProductCategoryStorageSorterInterface;
 use Spryker\Client\ProductCategoryStorage\Storage\ProductAbstractCategoryStorageReader;
 
 class ProductCategoryStorageFactory extends AbstractFactory
@@ -17,13 +21,33 @@ class ProductCategoryStorageFactory extends AbstractFactory
      */
     public function createProductCategoryStorageReader()
     {
-        return new ProductAbstractCategoryStorageReader($this->getStorage(), $this->getSynchronizationService());
+        return new ProductAbstractCategoryStorageReader(
+            $this->getStorage(),
+            $this->getSynchronizationService(),
+            $this->getProductAbstractCategoryStorageCollectionExpanderPlugins(),
+        );
+    }
+
+    /**
+     * @return \Spryker\Client\ProductCategoryStorage\Filter\ProductCategoryStorageFilterInterface
+     */
+    public function createProductCategoryStorageFilter(): ProductCategoryStorageFilterInterface
+    {
+        return new ProductCategoryStorageFilter();
+    }
+
+    /**
+     * @return \Spryker\Client\ProductCategoryStorage\Sorter\ProductCategoryStorageSorterInterface
+     */
+    public function createProductCategoryStorageSorter(): ProductCategoryStorageSorterInterface
+    {
+        return new ProductCategoryStorageSorter();
     }
 
     /**
      * @return \Spryker\Client\ProductCategoryStorage\Dependency\Client\ProductCategoryStorageToStorageClientInterface
      */
-    protected function getStorage()
+    public function getStorage()
     {
         return $this->getProvidedDependency(ProductCategoryStorageDependencyProvider::CLIENT_STORAGE);
     }
@@ -31,8 +55,16 @@ class ProductCategoryStorageFactory extends AbstractFactory
     /**
      * @return \Spryker\Client\ProductCategoryStorage\Dependency\Service\ProductCategoryStorageToSynchronizationServiceBridge
      */
-    protected function getSynchronizationService()
+    public function getSynchronizationService()
     {
         return $this->getProvidedDependency(ProductCategoryStorageDependencyProvider::SERVICE_SYNCHRONIZATION);
+    }
+
+    /**
+     * @return array<\Spryker\Client\ProductCategoryStorageExtension\Dependency\Plugin\ProductAbstractCategoryStorageCollectionExpanderPluginInterface>
+     */
+    public function getProductAbstractCategoryStorageCollectionExpanderPlugins(): array
+    {
+        return $this->getProvidedDependency(ProductCategoryStorageDependencyProvider::PLUGINS_PRODUCT_ABSTRACT_CATEGORY_STORAGE_COLLECTION_EXPANDER);
     }
 }

--- a/src/Spryker/Client/ProductCategoryStorage/Sorter/ProductCategoryStorageSorter.php
+++ b/src/Spryker/Client/ProductCategoryStorage/Sorter/ProductCategoryStorageSorter.php
@@ -12,9 +12,9 @@ use Generated\Shared\Transfer\ProductCategoryStorageTransfer;
 class ProductCategoryStorageSorter implements ProductCategoryStorageSorterInterface
 {
     /**
-     * @param array<\Generated\Shared\Transfer\ProductCategoryStorageTransfer> $productCategoryStorageTransfers
+     * @param array<int, \Generated\Shared\Transfer\ProductCategoryStorageTransfer> $productCategoryStorageTransfers
      *
-     * @return array<\Generated\Shared\Transfer\ProductCategoryStorageTransfer>
+     * @return list<\Generated\Shared\Transfer\ProductCategoryStorageTransfer>
      */
     public function sortProductCategories(array $productCategoryStorageTransfers): array
     {
@@ -50,11 +50,11 @@ class ProductCategoryStorageSorter implements ProductCategoryStorageSorterInterf
 
     /**
      * @param \Generated\Shared\Transfer\ProductCategoryStorageTransfer $productCategoryStorageTransfer
-     * @param array<\Generated\Shared\Transfer\ProductCategoryStorageTransfer> $productCategoryStorageTransfers
-     * @param array<\Generated\Shared\Transfer\ProductCategoryStorageTransfer> $sortedProductCategoryStorageTransfers
-     * @param array<int> $alreadySortedCategoryIds
+     * @param list<\Generated\Shared\Transfer\ProductCategoryStorageTransfer> $productCategoryStorageTransfers
+     * @param list<\Generated\Shared\Transfer\ProductCategoryStorageTransfer> $sortedProductCategoryStorageTransfers
+     * @param list<int> $alreadySortedCategoryIds
      *
-     * @return array<\Generated\Shared\Transfer\ProductCategoryStorageTransfer>
+     * @return list<\Generated\Shared\Transfer\ProductCategoryStorageTransfer>
      */
     protected function addParentProductCategoryStorageTransfer(
         ProductCategoryStorageTransfer $productCategoryStorageTransfer,
@@ -79,7 +79,7 @@ class ProductCategoryStorageSorter implements ProductCategoryStorageSorterInterf
     }
 
     /**
-     * @param array<\Generated\Shared\Transfer\ProductCategoryStorageTransfer> $productCategoryStorageTransfers
+     * @param list<\Generated\Shared\Transfer\ProductCategoryStorageTransfer> $productCategoryStorageTransfers
      * @param \Generated\Shared\Transfer\ProductCategoryStorageTransfer $childProductCategoryStorageTransfer
      *
      * @return \Generated\Shared\Transfer\ProductCategoryStorageTransfer|null
@@ -99,10 +99,10 @@ class ProductCategoryStorageSorter implements ProductCategoryStorageSorterInterf
 
     /**
      * @param \Generated\Shared\Transfer\ProductCategoryStorageTransfer $productCategoryStorageTransfer
-     * @param array<\Generated\Shared\Transfer\ProductCategoryStorageTransfer> $sortedProductCategoryStorageTransfers
-     * @param array<int> $alreadySortedCategoryIds
+     * @param list<\Generated\Shared\Transfer\ProductCategoryStorageTransfer> $sortedProductCategoryStorageTransfers
+     * @param list<int> $alreadySortedCategoryIds
      *
-     * @return array<\Generated\Shared\Transfer\ProductCategoryStorageTransfer>
+     * @return list<\Generated\Shared\Transfer\ProductCategoryStorageTransfer>
      */
     protected function addSortedProductCategoryStorageTransfer(
         ProductCategoryStorageTransfer $productCategoryStorageTransfer,
@@ -119,11 +119,11 @@ class ProductCategoryStorageSorter implements ProductCategoryStorageSorterInterf
 
     /**
      * @param \Generated\Shared\Transfer\ProductCategoryStorageTransfer $productCategoryStorageTransfer
-     * @param array<\Generated\Shared\Transfer\ProductCategoryStorageTransfer> $productCategoryStorageTransfers
-     * @param array<\Generated\Shared\Transfer\ProductCategoryStorageTransfer> $sortedProductCategoryStorageTransfers
-     * @param array<int> $alreadySortedCategoryIds
+     * @param list<\Generated\Shared\Transfer\ProductCategoryStorageTransfer> $productCategoryStorageTransfers
+     * @param list<\Generated\Shared\Transfer\ProductCategoryStorageTransfer> $sortedProductCategoryStorageTransfers
+     * @param list<int> $alreadySortedCategoryIds
      *
-     * @return array<\Generated\Shared\Transfer\ProductCategoryStorageTransfer>
+     * @return list<\Generated\Shared\Transfer\ProductCategoryStorageTransfer>
      */
     protected function addChildProductCategoryStorageTransfer(
         ProductCategoryStorageTransfer $productCategoryStorageTransfer,
@@ -148,7 +148,7 @@ class ProductCategoryStorageSorter implements ProductCategoryStorageSorterInterf
     }
 
     /**
-     * @param array<\Generated\Shared\Transfer\ProductCategoryStorageTransfer> $productCategoryStorageTransfers
+     * @param list<\Generated\Shared\Transfer\ProductCategoryStorageTransfer> $productCategoryStorageTransfers
      * @param \Generated\Shared\Transfer\ProductCategoryStorageTransfer $parentProductCategoryStorageTransfer
      *
      * @return \Generated\Shared\Transfer\ProductCategoryStorageTransfer|null

--- a/src/Spryker/Client/ProductCategoryStorage/Sorter/ProductCategoryStorageSorter.php
+++ b/src/Spryker/Client/ProductCategoryStorage/Sorter/ProductCategoryStorageSorter.php
@@ -1,0 +1,168 @@
+<?php
+
+/**
+ * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
+ * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
+ */
+
+namespace Spryker\Client\ProductCategoryStorage\Sorter;
+
+use Generated\Shared\Transfer\ProductCategoryStorageTransfer;
+
+class ProductCategoryStorageSorter implements ProductCategoryStorageSorterInterface
+{
+    /**
+     * @param array<\Generated\Shared\Transfer\ProductCategoryStorageTransfer> $productCategoryStorageTransfers
+     *
+     * @return array<\Generated\Shared\Transfer\ProductCategoryStorageTransfer>
+     */
+    public function sortProductCategories(array $productCategoryStorageTransfers): array
+    {
+        $sortedProductCategoryStorageTransfers = [];
+        $alreadySortedCategoryIds = [];
+
+        foreach ($productCategoryStorageTransfers as $key => $productCategoryStorageTransfer) {
+            unset($productCategoryStorageTransfers[$key]);
+
+            $sortedProductCategoryStorageTransfers = $this->addParentProductCategoryStorageTransfer(
+                $productCategoryStorageTransfer,
+                $productCategoryStorageTransfers,
+                $sortedProductCategoryStorageTransfers,
+                $alreadySortedCategoryIds,
+            );
+
+            $sortedProductCategoryStorageTransfers = $this->addSortedProductCategoryStorageTransfer(
+                $productCategoryStorageTransfer,
+                $sortedProductCategoryStorageTransfers,
+                $alreadySortedCategoryIds,
+            );
+
+            $sortedProductCategoryStorageTransfers = $this->addChildProductCategoryStorageTransfer(
+                $productCategoryStorageTransfer,
+                $productCategoryStorageTransfers,
+                $sortedProductCategoryStorageTransfers,
+                $alreadySortedCategoryIds,
+            );
+        }
+
+        return $sortedProductCategoryStorageTransfers;
+    }
+
+    /**
+     * @param \Generated\Shared\Transfer\ProductCategoryStorageTransfer $productCategoryStorageTransfer
+     * @param array<\Generated\Shared\Transfer\ProductCategoryStorageTransfer> $productCategoryStorageTransfers
+     * @param array<\Generated\Shared\Transfer\ProductCategoryStorageTransfer> $sortedProductCategoryStorageTransfers
+     * @param array<int> $alreadySortedCategoryIds
+     *
+     * @return array<\Generated\Shared\Transfer\ProductCategoryStorageTransfer>
+     */
+    protected function addParentProductCategoryStorageTransfer(
+        ProductCategoryStorageTransfer $productCategoryStorageTransfer,
+        array $productCategoryStorageTransfers,
+        array $sortedProductCategoryStorageTransfers,
+        array &$alreadySortedCategoryIds
+    ): array {
+        $parentProductCategoryStorageTransfer = $this->getParentProductCategoryStorageTransfer(
+            $productCategoryStorageTransfers,
+            $productCategoryStorageTransfer,
+        );
+
+        if ($parentProductCategoryStorageTransfer) {
+            $sortedProductCategoryStorageTransfers = $this->addSortedProductCategoryStorageTransfer(
+                $parentProductCategoryStorageTransfer,
+                $sortedProductCategoryStorageTransfers,
+                $alreadySortedCategoryIds,
+            );
+        }
+
+        return $sortedProductCategoryStorageTransfers;
+    }
+
+    /**
+     * @param array<\Generated\Shared\Transfer\ProductCategoryStorageTransfer> $productCategoryStorageTransfers
+     * @param \Generated\Shared\Transfer\ProductCategoryStorageTransfer $childProductCategoryStorageTransfer
+     *
+     * @return \Generated\Shared\Transfer\ProductCategoryStorageTransfer|null
+     */
+    protected function getParentProductCategoryStorageTransfer(
+        array $productCategoryStorageTransfers,
+        ProductCategoryStorageTransfer $childProductCategoryStorageTransfer
+    ): ?ProductCategoryStorageTransfer {
+        foreach ($productCategoryStorageTransfers as $productCategoryStorageTransfer) {
+            if (in_array($productCategoryStorageTransfer->getCategoryIdOrFail(), $childProductCategoryStorageTransfer->getParentCategoryIds(), true)) {
+                return $productCategoryStorageTransfer;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @param \Generated\Shared\Transfer\ProductCategoryStorageTransfer $productCategoryStorageTransfer
+     * @param array<\Generated\Shared\Transfer\ProductCategoryStorageTransfer> $sortedProductCategoryStorageTransfers
+     * @param array<int> $alreadySortedCategoryIds
+     *
+     * @return array<\Generated\Shared\Transfer\ProductCategoryStorageTransfer>
+     */
+    protected function addSortedProductCategoryStorageTransfer(
+        ProductCategoryStorageTransfer $productCategoryStorageTransfer,
+        array $sortedProductCategoryStorageTransfers,
+        array &$alreadySortedCategoryIds
+    ): array {
+        if (!in_array($productCategoryStorageTransfer->getCategoryIdOrFail(), $alreadySortedCategoryIds, true)) {
+            $sortedProductCategoryStorageTransfers[] = $productCategoryStorageTransfer;
+            $alreadySortedCategoryIds[] = $productCategoryStorageTransfer->getCategoryIdOrFail();
+        }
+
+        return $sortedProductCategoryStorageTransfers;
+    }
+
+    /**
+     * @param \Generated\Shared\Transfer\ProductCategoryStorageTransfer $productCategoryStorageTransfer
+     * @param array<\Generated\Shared\Transfer\ProductCategoryStorageTransfer> $productCategoryStorageTransfers
+     * @param array<\Generated\Shared\Transfer\ProductCategoryStorageTransfer> $sortedProductCategoryStorageTransfers
+     * @param array<int> $alreadySortedCategoryIds
+     *
+     * @return array<\Generated\Shared\Transfer\ProductCategoryStorageTransfer>
+     */
+    protected function addChildProductCategoryStorageTransfer(
+        ProductCategoryStorageTransfer $productCategoryStorageTransfer,
+        array $productCategoryStorageTransfers,
+        array $sortedProductCategoryStorageTransfers,
+        array &$alreadySortedCategoryIds
+    ): array {
+        $childProductCategoryStorageTransfer = $this->getChildProductCategoryStorageTransfer(
+            $productCategoryStorageTransfers,
+            $productCategoryStorageTransfer,
+        );
+
+        if ($childProductCategoryStorageTransfer) {
+            $sortedProductCategoryStorageTransfers = $this->addSortedProductCategoryStorageTransfer(
+                $childProductCategoryStorageTransfer,
+                $sortedProductCategoryStorageTransfers,
+                $alreadySortedCategoryIds,
+            );
+        }
+
+        return $sortedProductCategoryStorageTransfers;
+    }
+
+    /**
+     * @param array<\Generated\Shared\Transfer\ProductCategoryStorageTransfer> $productCategoryStorageTransfers
+     * @param \Generated\Shared\Transfer\ProductCategoryStorageTransfer $parentProductCategoryStorageTransfer
+     *
+     * @return \Generated\Shared\Transfer\ProductCategoryStorageTransfer|null
+     */
+    protected function getChildProductCategoryStorageTransfer(
+        array $productCategoryStorageTransfers,
+        ProductCategoryStorageTransfer $parentProductCategoryStorageTransfer
+    ): ?ProductCategoryStorageTransfer {
+        foreach ($productCategoryStorageTransfers as $productCategoryStorageTransfer) {
+            if (in_array($parentProductCategoryStorageTransfer->getCategoryIdOrFail(), $productCategoryStorageTransfer->getParentCategoryIds(), true)) {
+                return $productCategoryStorageTransfer;
+            }
+        }
+
+        return null;
+    }
+}

--- a/src/Spryker/Client/ProductCategoryStorage/Sorter/ProductCategoryStorageSorterInterface.php
+++ b/src/Spryker/Client/ProductCategoryStorage/Sorter/ProductCategoryStorageSorterInterface.php
@@ -1,0 +1,18 @@
+<?php
+
+/**
+ * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
+ * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
+ */
+
+namespace Spryker\Client\ProductCategoryStorage\Sorter;
+
+interface ProductCategoryStorageSorterInterface
+{
+    /**
+     * @param array<\Generated\Shared\Transfer\ProductCategoryStorageTransfer> $productCategoryStorageTransfers
+     *
+     * @return array<\Generated\Shared\Transfer\ProductCategoryStorageTransfer>
+     */
+    public function sortProductCategories(array $productCategoryStorageTransfers): array;
+}

--- a/src/Spryker/Client/ProductCategoryStorage/Sorter/ProductCategoryStorageSorterInterface.php
+++ b/src/Spryker/Client/ProductCategoryStorage/Sorter/ProductCategoryStorageSorterInterface.php
@@ -10,9 +10,9 @@ namespace Spryker\Client\ProductCategoryStorage\Sorter;
 interface ProductCategoryStorageSorterInterface
 {
     /**
-     * @param array<\Generated\Shared\Transfer\ProductCategoryStorageTransfer> $productCategoryStorageTransfers
+     * @param array<int, \Generated\Shared\Transfer\ProductCategoryStorageTransfer> $productCategoryStorageTransfers
      *
-     * @return array<\Generated\Shared\Transfer\ProductCategoryStorageTransfer>
+     * @return list<\Generated\Shared\Transfer\ProductCategoryStorageTransfer>
      */
     public function sortProductCategories(array $productCategoryStorageTransfers): array;
 }

--- a/src/Spryker/Client/ProductCategoryStorage/Storage/ProductAbstractCategoryStorageReader.php
+++ b/src/Spryker/Client/ProductCategoryStorage/Storage/ProductAbstractCategoryStorageReader.php
@@ -51,11 +51,10 @@ class ProductAbstractCategoryStorageReader implements ProductAbstractCategorySto
     /**
      * @param int $idProductAbstract
      * @param string $locale
-     * @param string $storeName
      *
      * @return \Generated\Shared\Transfer\ProductAbstractCategoryStorageTransfer|null
      */
-    public function findProductAbstractCategory($idProductAbstract, $locale, string $storeName)
+    public function findProductAbstractCategory($idProductAbstract, $locale)
     {
         $productAbstractCategoryStorageData = $this->findStorageData($idProductAbstract, $locale);
 
@@ -63,29 +62,19 @@ class ProductAbstractCategoryStorageReader implements ProductAbstractCategorySto
             return null;
         }
 
-        $productAbstractCategoryStorageTransfer = (new ProductAbstractCategoryStorageTransfer())->fromArray($productAbstractCategoryStorageData, true);
+        $spyProductCategoryAbstractTransfer = new ProductAbstractCategoryStorageTransfer();
 
-        $productAbstractCategoryStorageCollectionTransfer = (new ProductAbstractCategoryStorageCollectionTransfer())
-            ->addProductAbstractCategory($productAbstractCategoryStorageTransfer);
-
-        $productAbstractCategoryStorageCollectionTransfer = $this->executeProductAbstractCategoryStorageCollectionExpanderPlugins(
-            $productAbstractCategoryStorageCollectionTransfer,
-            $locale,
-            $storeName,
-        );
-
-        $productAbstractCategoryStorageTransfers = $productAbstractCategoryStorageCollectionTransfer->getProductAbstractCategories()->getArrayCopy();
-
-        return array_pop($productAbstractCategoryStorageTransfers);
+        return $spyProductCategoryAbstractTransfer->fromArray($productAbstractCategoryStorageData, true);
     }
 
     /**
      * @param int[] $productAbstractIds
      * @param string $localeName
+     * @param string $storeName
      *
      * @return \Generated\Shared\Transfer\ProductAbstractCategoryStorageTransfer[]
      */
-    public function findBulkProductAbstractCategory(array $productAbstractIds, string $localeName): array
+    public function findBulkProductAbstractCategory(array $productAbstractIds, string $localeName, string $storeName): array
     {
         $productAbstractCategoryStorageData = $this->findBulkStorageData($productAbstractIds, $localeName);
         $productAbstractCategoryStorageData = array_filter($productAbstractCategoryStorageData);
@@ -94,13 +83,19 @@ class ProductAbstractCategoryStorageReader implements ProductAbstractCategorySto
             return [];
         }
 
-        $response = [];
+        $productAbstractCategoryStorageCollectionTransfer = new ProductAbstractCategoryStorageCollectionTransfer();
         foreach ($productAbstractCategoryStorageData as $item) {
-            $response[] = (new ProductAbstractCategoryStorageTransfer())
-                ->fromArray($item, true);
+            $productAbstractCategoryStorageTransfer = (new ProductAbstractCategoryStorageTransfer())->fromArray($item, true);
+            $productAbstractCategoryStorageCollectionTransfer->addProductAbstractCategory($productAbstractCategoryStorageTransfer);
         }
 
-        return $response;
+        $productAbstractCategoryStorageCollectionTransfer = $this->executeProductAbstractCategoryStorageCollectionExpanderPlugins(
+            $productAbstractCategoryStorageCollectionTransfer,
+            $localeName,
+            $storeName,
+        );
+
+        return $productAbstractCategoryStorageCollectionTransfer->getProductAbstractCategories()->getArrayCopy();
     }
 
     /**

--- a/src/Spryker/Client/ProductCategoryStorage/Storage/ProductAbstractCategoryStorageReader.php
+++ b/src/Spryker/Client/ProductCategoryStorage/Storage/ProductAbstractCategoryStorageReader.php
@@ -29,14 +29,14 @@ class ProductAbstractCategoryStorageReader implements ProductAbstractCategorySto
     protected $synchronizationService;
 
     /**
-     * @var array<\Spryker\Client\ProductCategoryStorageExtension\Dependency\Plugin\ProductAbstractCategoryStorageCollectionExpanderPluginInterface>
+     * @var list<\Spryker\Client\ProductCategoryStorageExtension\Dependency\Plugin\ProductAbstractCategoryStorageCollectionExpanderPluginInterface>
      */
     protected $productAbstractCategoryStorageCollectionExpanderPlugins;
 
     /**
      * @param \Spryker\Client\ProductCategoryStorage\Dependency\Client\ProductCategoryStorageToStorageClientInterface $storageClient
      * @param \Spryker\Client\ProductCategoryStorage\Dependency\Service\ProductCategoryStorageToSynchronizationServiceInterface $synchronizationService
-     * @param array<\Spryker\Client\ProductCategoryStorageExtension\Dependency\Plugin\ProductAbstractCategoryStorageCollectionExpanderPluginInterface> $productAbstractCategoryStorageCollectionExpanderPlugins
+     * @param list<\Spryker\Client\ProductCategoryStorageExtension\Dependency\Plugin\ProductAbstractCategoryStorageCollectionExpanderPluginInterface> $productAbstractCategoryStorageCollectionExpanderPlugins
      */
     public function __construct(
         ProductCategoryStorageToStorageClientInterface $storageClient,
@@ -66,7 +66,7 @@ class ProductAbstractCategoryStorageReader implements ProductAbstractCategorySto
         $productAbstractCategoryStorageTransfer = (new ProductAbstractCategoryStorageTransfer())->fromArray($productAbstractCategoryStorageData, true);
 
         $productAbstractCategoryStorageCollectionTransfer = (new ProductAbstractCategoryStorageCollectionTransfer())
-            ->addProductAbstractCategoryStorage($productAbstractCategoryStorageTransfer);
+            ->addProductAbstractCategory($productAbstractCategoryStorageTransfer);
 
         $productAbstractCategoryStorageCollectionTransfer = $this->executeProductAbstractCategoryStorageCollectionExpanderPlugins(
             $productAbstractCategoryStorageCollectionTransfer,
@@ -74,9 +74,9 @@ class ProductAbstractCategoryStorageReader implements ProductAbstractCategorySto
             $storeName,
         );
 
-        $productAbstractCategoryStorageTransfersData = $productAbstractCategoryStorageCollectionTransfer->getProductAbstractCategories()->getArrayCopy();
+        $productAbstractCategoryStorageTransfers = $productAbstractCategoryStorageCollectionTransfer->getProductAbstractCategories()->getArrayCopy();
 
-        return array_pop($productAbstractCategoryStorageTransfersData);
+        return array_pop($productAbstractCategoryStorageTransfers);
     }
 
     /**

--- a/src/Spryker/Client/ProductCategoryStorage/Storage/ProductAbstractCategoryStorageReaderInterface.php
+++ b/src/Spryker/Client/ProductCategoryStorage/Storage/ProductAbstractCategoryStorageReaderInterface.php
@@ -12,17 +12,17 @@ interface ProductAbstractCategoryStorageReaderInterface
     /**
      * @param int $idProductAbstract
      * @param string $locale
-     * @param string $storeName
      *
      * @return \Generated\Shared\Transfer\ProductAbstractCategoryStorageTransfer|null
      */
-    public function findProductAbstractCategory($idProductAbstract, $locale, string $storeName);
+    public function findProductAbstractCategory($idProductAbstract, $locale);
 
     /**
      * @param int[] $productAbstractIds
      * @param string $localeName
+     * @param string $storeName
      *
      * @return \Generated\Shared\Transfer\ProductAbstractCategoryStorageTransfer[]
      */
-    public function findBulkProductAbstractCategory(array $productAbstractIds, string $localeName): array;
+    public function findBulkProductAbstractCategory(array $productAbstractIds, string $localeName, string $storeName): array;
 }

--- a/src/Spryker/Client/ProductCategoryStorage/Storage/ProductAbstractCategoryStorageReaderInterface.php
+++ b/src/Spryker/Client/ProductCategoryStorage/Storage/ProductAbstractCategoryStorageReaderInterface.php
@@ -12,10 +12,11 @@ interface ProductAbstractCategoryStorageReaderInterface
     /**
      * @param int $idProductAbstract
      * @param string $locale
+     * @param string $storeName
      *
      * @return \Generated\Shared\Transfer\ProductAbstractCategoryStorageTransfer|null
      */
-    public function findProductAbstractCategory($idProductAbstract, $locale);
+    public function findProductAbstractCategory($idProductAbstract, $locale, string $storeName);
 
     /**
      * @param int[] $productAbstractIds

--- a/src/Spryker/Shared/ProductCategoryStorage/Transfer/product_category_storage.transfer.xml
+++ b/src/Spryker/Shared/ProductCategoryStorage/Transfer/product_category_storage.transfer.xml
@@ -8,6 +8,7 @@
         <property name="categoryId" type="int"/>
         <property name="name" type="string"/>
         <property name="url" type="string"/>
+        <property name="parentCategoryIds" type="int[]" singular="parentCategoryIds" strict="true"/>
     </transfer>
 
     <transfer name="ProductAbstractCategoryStorage">
@@ -22,6 +23,10 @@
 
     <transfer name="Node">
         <property name="idCategoryNode" type="int"/>
+    </transfer>
+
+    <transfer name="ProductAbstractCategoryStorageCollection" strict="true">
+        <property name="productAbstractCategories" type="ProductAbstractCategoryStorage[]" singular="productAbstractCategoryStorage"/>
     </transfer>
 
 </transfers>

--- a/src/Spryker/Shared/ProductCategoryStorage/Transfer/product_category_storage.transfer.xml
+++ b/src/Spryker/Shared/ProductCategoryStorage/Transfer/product_category_storage.transfer.xml
@@ -8,7 +8,7 @@
         <property name="categoryId" type="int"/>
         <property name="name" type="string"/>
         <property name="url" type="string"/>
-        <property name="parentCategoryIds" type="int[]" singular="parentCategoryIds" strict="true"/>
+        <property name="parentCategoryIds" type="int[]" singular="idParentCategory" strict="true"/>
     </transfer>
 
     <transfer name="ProductAbstractCategoryStorage">
@@ -26,7 +26,7 @@
     </transfer>
 
     <transfer name="ProductAbstractCategoryStorageCollection" strict="true">
-        <property name="productAbstractCategories" type="ProductAbstractCategoryStorage[]" singular="productAbstractCategoryStorage"/>
+        <property name="productAbstractCategories" type="ProductAbstractCategoryStorage[]" singular="productAbstractCategory"/>
     </transfer>
 
 </transfers>


### PR DESCRIPTION
- Branch: backport/1.11.0
- Ticket: https://spryker.atlassian.net/browse/SUPESC-193
- Version: 1.11.0

#### Release Table

   Module                | Release Type         | Constraint Updates         |
   :--------------------- | :------------------------ | :--------------------- |
   ProductCategoryStorage           | minor                 | ProductCategoryStorageExtension                   |
   
-----------------------------------------

#### Module ProductCategoryStorage

##### Change log

Improvements

- Introduced `ProductCategoryStorageClient::filterProductCategoriesByHttpReferer()` to filter product categories by http referer.
- Introduced `ProductCategoryStorageClient::sortProductCategories()` to sort product categories in order from parent to child.
- Adjusted `ProductAbstractCategoryStorageReader::findBulkProductAbstractCategory()` to expand product abstract categories by `ProductAbstractCategoryStorageCollectionExpanderPluginInterface`  plugin stack execution.
- Impacted `ProductCategoryStorageClient::findBulkProductAbstractCategory()` by these changes.
- Introduced `ProductAbstractCategoryStorageCollection` transfer.
- Introduced `ProductCategoryStorage.parentCategoryIds` transfer field.
- Added `ProductCategoryStorageExtension` module to dependencies.
- Added `Transfer` module to dependencies.

Deprecations

- Deprecated `ProductCategoryStorageClient::findProductAbstractCategory()`.